### PR TITLE
Use inventory_hostname instead of ansible_host

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -27,7 +27,7 @@
   ansible.builtin.wait_for:
     port: "{{ ansible_port }}"
     state: "started"
-    host: "{{ ansible_host }}"
+    host: "{{ inventory_hostname }}"
     connect_timeout: "5"
     timeout: "10"
   delegate_to: "localhost"
@@ -48,7 +48,7 @@
   ansible.builtin.wait_for:
     port: "22"
     state: "started"
-    host: "{{ ansible_host }}"
+    host: "{{ inventory_hostname }}"
     connect_timeout: "5"
     timeout: "10"
   delegate_to: "localhost"


### PR DESCRIPTION
Based on this article, it probably makes sense to use `inventory_hostname` instead of `ansible_host`

https://middlewareinventory.com/blog/ansible-inventory_hostname-ansible_hostname-variables/#Inventory_hostname_variable_Introduction